### PR TITLE
fix(docker-compose.yml): use the .env at the root of the repo for the…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       context: ./front
       dockerfile: Dockerfile
     restart: always
+    env_file:
+      - .env
     ports:
       - "8080:80"
     networks:


### PR DESCRIPTION
… front